### PR TITLE
select standings

### DIFF
--- a/src/components/ui/Selectstanding.tsx
+++ b/src/components/ui/Selectstanding.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  children: React.ReactNode;
+}
+
+const Select: React.FC<SelectProps> = ({ children, ...props }) => {
+  return (
+    <select
+      {...props}
+      className="bg-accent-800 text-white px-3 py-2 rounded-md border border-accent-600 focus:outline-none focus:ring focus:ring-primary-500"
+    >
+      {children}
+    </select>
+  );
+};
+
+export default Select;

--- a/src/pages/Standing.tsx
+++ b/src/pages/Standing.tsx
@@ -6,7 +6,7 @@ import {
   GET_LIGUE_CLASSEMENT,
 } from '../graphql/queries';
 import Layout from '../components/layout/Layout';
-import Select from '../components/ui/Select';
+import Select from '../components/ui/Selectstanding';
 import { Trophy } from 'lucide-react';
 
 const Standing: React.FC = () => {


### PR DESCRIPTION
This pull request introduces a new `Select` component in `src/components/ui/Selectstanding.tsx` and updates its usage in the `Standing.tsx` page. The changes focus on improving the UI by providing a reusable and styled dropdown component.

### Component Addition:
* [`src/components/ui/Selectstanding.tsx`](diffhunk://#diff-8b2964c8c9ffbd236d4d3b17a4841830197f012ed91c951435eaeb0dfe1b22eeR1-R18): Added a new `Select` component with customizable props and children, styled with Tailwind CSS for consistent UI design.

### Component Integration:
* [`src/pages/Standing.tsx`](diffhunk://#diff-b19f71c6e6d5f80307b5a086d231b89475a5c3ae6fc39cafa1f6cc8c39fb5229L9-R9): Updated the import path to use the newly created `Select` component from `Selectstanding.tsx`.